### PR TITLE
Use new permissions only for android.os.Build.VERSION_CODES.S

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -31,7 +31,8 @@
 
         <config-file target="AndroidManifest.xml" parent="/manifest">
             <!--BLUETOOTH PERMISSION-->
-            <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+            <uses-permission android:name="android.permission.BLUETOOTH" />
+            <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
             <!-- Needed only if your app looks for Bluetooth devices. If your app doesn't use Bluetooth scan results to derive physical location information, you can strongly assert that your app doesn't derive physical location. -->
             <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
                 android:usesPermissionFlags="neverForLocation"

--- a/src/android/com/megster/cordova/BluetoothSerial.java
+++ b/src/android/com/megster/cordova/BluetoothSerial.java
@@ -109,7 +109,7 @@ public class BluetoothSerial extends CordovaPlugin {
 
         if (action.equals(LIST)) {
 
-            if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+            if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
                 if (cordova.hasPermission(REQUEST_SCAN) && cordova.hasPermission(REQUEST_CONNECT)) {
                     listBondedDevices(callbackContext);
                 } else if (!cordova.hasPermission(REQUEST_CONNECT)) {
@@ -222,7 +222,7 @@ public class BluetoothSerial extends CordovaPlugin {
 
         } else if (action.equals(ENABLE)) {
 
-            if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+            if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
                 if (cordova.hasPermission(REQUEST_SCAN) && cordova.hasPermission(REQUEST_CONNECT)) {
                     enableBluetoothCallback = callbackContext;
                     Intent intent = new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE);
@@ -242,7 +242,7 @@ public class BluetoothSerial extends CordovaPlugin {
 
         } else if (action.equals(DISCOVER_UNPAIRED)) {
 
-            if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+            if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
                 if (cordova.hasPermission(ACCESS_FINE_LOCATION) && cordova.hasPermission(REQUEST_SCAN) && cordova.hasPermission(REQUEST_CONNECT)) {
                     discoverUnpairedDevices(callbackContext);
                 } else if (!cordova.hasPermission(ACCESS_FINE_LOCATION)) {
@@ -363,7 +363,7 @@ public class BluetoothSerial extends CordovaPlugin {
             }
         };
 
-        if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+        if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
             if (cordova.hasPermission(REQUEST_SCAN) && cordova.hasPermission(REQUEST_CONNECT)) {
                 Activity activity = cordova.getActivity();
                 activity.registerReceiver(discoverReceiver, new IntentFilter(BluetoothDevice.ACTION_FOUND));


### PR DESCRIPTION
Hi, first of all, thank you for your fork! It works perfectly on android 12, but have some problems on android 10 and 11.
The main problem is that `REQUEST_CONNECT` and `REQUEST_SCAN` are available from version `S`, I'm fixing it in this pull request.